### PR TITLE
Clamp shader intensity

### DIFF
--- a/src/shaders/baseSphere.frag.glsl
+++ b/src/shaders/baseSphere.frag.glsl
@@ -2,7 +2,7 @@ uniform vec3 color;
 varying vec3 vertexNormal;
 
 void main() {
-    float intensity = 0.9 - dot(vertexNormal, vec3(0.0, 0.0, 1.0));
+    float intensity = clamp(0.9 - dot(vertexNormal, vec3(0.0, 0.0, 1.0)), 0.0, 1.0);
     vec3 atmosphere = vec3(0.5, 0.7, 1.0) * pow(intensity, 4.5);
 
     gl_FragColor = vec4(atmosphere + color, 1);


### PR DESCRIPTION
Clamping the `intensity` variable for the fragment shader removes the visual artifact.

![Before](https://user-images.githubusercontent.com/12190184/139022520-a4c001d4-9a2b-45ef-896d-4e99aaa88d57.png)
![After](https://user-images.githubusercontent.com/12190184/139022524-00f51353-9b8e-4351-973f-aac463dcfb11.png)
